### PR TITLE
add Reader and Writer

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -99,7 +99,7 @@ func TestTooManyErrors(t *testing.T) {
 	if nb, err := d.Decode(complete[:len(QR_CODE_TEST_DATA)], complete[len(QR_CODE_TEST_DATA):]); err == nil {
 		t.Fatal("Recovered unrecoverable error!?!")
 	} else if nb != 0 {
-		t.Fatal("Err != %d", nb)
+		t.Fatalf("Err != %d", nb)
 	}
 }
 

--- a/field.go
+++ b/field.go
@@ -32,19 +32,28 @@ func NewField(poly int, α byte) *Field {
 
 func (f Field) GetPolyAlpha() (poly int, α byte) {
 	α = f.f.Exp(1)
-	alpha := int(α)
-	x := alpha
-	for i := 2; i < 255; i++ {
-		x *= alpha
-		y := int(f.f.Exp(i))
-		if x <= y {
+	for p := 0x100; p < 0x200; p++ {
+		g := newField(p, α)
+		if g == nil {
 			continue
 		}
-		for poly = 0x100; poly < 0x200; poly++ {
-			if poly%x == y {
-				return poly, α
+		ok := true
+		for i := 0; i < 255; i++ {
+			if g.f.Exp(i) != f.f.Exp(i) {
+				ok = false
+				break
 			}
+		}
+		if ok {
+			return p, α
 		}
 	}
 	return
+}
+
+func newField(poly int, α byte) (f *Field) {
+	defer func() {
+		recover()
+	}()
+	return NewField(poly, α)
 }

--- a/field.go
+++ b/field.go
@@ -21,16 +21,22 @@ var QR_CODE_FIELD_256 = NewField(0x11D, 2)
 
 // Field is a wrapper to gf256.Field so the type doesn't leak in.
 type Field struct {
-	f *gf256.Field
+	f    *gf256.Field
+	poly int
+	α    byte
 }
 
 // NewField wraps gf256.NewField(). It is safe to use the premade
 // QR_CODE_FIELD_256 all the time.
 func NewField(poly int, α byte) *Field {
-	return &Field{gf256.NewField(poly, int(α))}
+	return &Field{f: gf256.NewField(poly, int(α)), poly: poly, α: α}
 }
 
 func (f Field) GetPolyAlpha() (poly int, α byte) {
+	if f.poly >= 0x100 && poly <= 0x200 {
+		return f.poly, f.α
+	}
+	// guess
 	α = f.f.Exp(1)
 	for p := 0x100; p < 0x200; p++ {
 		g := newField(p, α)

--- a/field.go
+++ b/field.go
@@ -29,3 +29,22 @@ type Field struct {
 func NewField(poly int, α byte) *Field {
 	return &Field{gf256.NewField(poly, int(α))}
 }
+
+func (f Field) GetPolyAlpha() (poly int, α byte) {
+	α = f.f.Exp(1)
+	alpha := int(α)
+	x := alpha
+	for i := 2; i < 255; i++ {
+		x *= alpha
+		y := int(f.f.Exp(i))
+		if x <= y {
+			continue
+		}
+		for poly = 0x100; poly < 0x200; poly++ {
+			if poly%x == y {
+				return poly, α
+			}
+		}
+	}
+	return
+}

--- a/field.go
+++ b/field.go
@@ -19,7 +19,7 @@ import (
 // x^8 + x^4 + x^3 + x^2 + 1
 var QR_CODE_FIELD_256 = NewField(0x11D, 2)
 
-// Wrapper to gf256.Field so the type doesn't leak in.
+// Field is a wrapper to gf256.Field so the type doesn't leak in.
 type Field struct {
 	f *gf256.Field
 }

--- a/field_test.go
+++ b/field_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2014 Tamás Gulácsi.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0. Unless required by applicable law
+or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package rs
+
+import (
+	"testing"
+)
+
+func TestGetPolyAlpha(t *testing.T) {
+	for poly := 0x100; poly < 0x200; poly++ {
+		for α := byte(0); α < 255; α++ {
+			f := newField(poly, α)
+			if f == nil {
+				continue
+			}
+			poly2, α2 := f.GetPolyAlpha()
+			if poly != poly2 || α != α2 {
+				t.Errorf("got (%d, %d), awaited (%d, %d)", poly, α, poly2, α2)
+			}
+		}
+	}
+}

--- a/header.go
+++ b/header.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2014 Tamás Gulácsi.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0. Unless required by applicable law
+or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package rs
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type rSHeader struct {
+	Poly, C int
+	Alpha   byte
+}
+
+func readHeader(r io.Reader) (*Field, int, error) {
+	var hdr rSHeader
+	if err := json.NewDecoder(r).Decode(&hdr); err != nil {
+		return nil, 0, err
+	}
+	return NewField(hdr.Poly, hdr.Alpha), hdr.C, nil
+}
+
+func writeHeader(w io.Writer, f *Field, c int) (int, error) {
+	cw := &countingWriter{Writer: w}
+
+	// FIXME(tgulacsi): get poly and alpha from *Field
+	err := json.NewEncoder(cw).Encode(rSHeader{Poly: 0, Alpha: 0, C: c})
+	return int(cw.n), err
+}
+
+type countingWriter struct {
+	io.Writer
+	n int64
+}
+
+func (cw *countingWriter) Write(p []byte) (int, error) {
+	n, err := cw.Writer.Write(p)
+	cw.n += int64(n)
+	return n, err
+}

--- a/reader.go
+++ b/reader.go
@@ -26,8 +26,19 @@ type rSReader struct {
 	corr            int64 //corrected byte count
 }
 
-// NewReader returns a reader correcting on-the-fly
-func NewReader(r io.Reader, f *Field, c int) io.Reader {
+// NewInterleavedReader returns a reader correcting on-the-fly.
+//
+// This reads the field and the c parameter from the data header.
+func NewInterleavedReader(r io.Reader) (io.Reader, error) {
+	f, c, err := readHeader(r)
+	if err != nil {
+		return nil, err
+	}
+	return NewInterleavedReaderField(r, f, c), nil
+}
+
+// NewInterleavedReaderField returns a reader correcting on-the-fly
+func NewInterleavedReaderField(r io.Reader, f *Field, c int) io.Reader {
 	return &rSReader{
 		dataLen: maxDataLen - c,
 		eccLen:  c,

--- a/reader.go
+++ b/reader.go
@@ -30,7 +30,7 @@ type rSReader struct {
 //
 // This reads the field and the c parameter from the data header.
 func NewInterleavedReader(r io.Reader) (io.Reader, error) {
-	f, c, err := readHeader(r)
+	r, f, c, err := readHeader(r)
 	if err != nil {
 		return nil, err
 	}

--- a/reader.go
+++ b/reader.go
@@ -27,11 +27,11 @@ type rSReader struct {
 }
 
 // NewReader returns a reader correcting on-the-fly
-func NewReader(r io.Reader, c int) io.Reader {
+func NewReader(r io.Reader, f *Field, c int) io.Reader {
 	return &rSReader{
 		dataLen: maxDataLen - c,
 		eccLen:  c,
-		d:       NewDecoder(QR_CODE_FIELD_256),
+		d:       NewDecoder(f),
 		r:       r,
 		block:   make([]byte, maxDataLen),
 	}

--- a/readwrite_test.go
+++ b/readwrite_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2014 Tamás Gulácsi.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0. Unless required by applicable law
+or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package rs
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha1"
+	"io"
+	"testing"
+)
+
+const eccLen = 32
+
+var rounds = 32
+
+func TestReadWrite(t *testing.T) {
+	randBytes := make([]byte, maxDataLen-eccLen-1)
+	n, err := rand.Read(randBytes)
+	if err != nil {
+		t.Fatalf("error reading rand bytes: %v", err)
+	}
+	randBytes = randBytes[:n]
+
+	for i := 0; i < rounds && i < len(randBytes); i++ {
+		encrypted := bytes.NewBuffer(nil)
+		wr := NewWriter(encrypted, eccLen)
+		hsh := sha1.New()
+		var written int64
+
+		w := io.MultiWriter(wr, hsh)
+		for j := 0; j <= i; j++ {
+			if n, err = w.Write(randBytes); err != nil {
+				t.Fatalf("error writing: %v", err)
+			}
+			written += int64(n)
+			if i > 0 {
+				if n, err = w.Write(randBytes[:i]); err != nil {
+					t.Fatalf("error writing: %v", err)
+				}
+				written += int64(n)
+			}
+		}
+		if err = wr.Close(); err != nil {
+			t.Fatalf("error closing: %v", err)
+		}
+
+		// check
+		origHash := hsh.Sum(nil)
+		t.Logf("written %d raw bytes, %d encrypted, hash is %x", written, encrypted.Len(), origHash)
+
+		hsh = sha1.New()
+		rdr := NewReader(bytes.NewReader(encrypted.Bytes()), eccLen)
+		read, err := io.Copy(hsh, rdr)
+		if err != nil {
+			t.Errorf("error reading: %v", err)
+		}
+		if read != written {
+			t.Errorf("length mismatch: written %d, read %d", written, read)
+		}
+
+		readHash := hsh.Sum(nil)
+		t.Logf("read %d bytes, hash is %x", read, readHash)
+		if !bytes.Equal(readHash, origHash) {
+			t.Fatalf("hash mismatch: written %x read %x", origHash, readHash)
+		}
+	}
+}

--- a/readwrite_test.go
+++ b/readwrite_test.go
@@ -36,7 +36,7 @@ func TestReadWrite(t *testing.T) {
 
 	for i := 0; i < rounds && i < len(randBytes); i++ {
 		encrypted := bytes.NewBuffer(nil)
-		wr := NewWriter(encrypted, eccLen)
+		wr := NewWriter(encrypted, QR_CODE_FIELD_256, eccLen)
 		hsh := sha1.New()
 		var written int64
 
@@ -62,7 +62,7 @@ func TestReadWrite(t *testing.T) {
 		t.Logf("written %d raw bytes, %d encrypted, hash is %x", written, encrypted.Len(), origHash)
 
 		hsh = sha1.New()
-		rdr := NewReader(bytes.NewReader(encrypted.Bytes()), eccLen)
+		rdr := NewReader(bytes.NewReader(encrypted.Bytes()), QR_CODE_FIELD_256, eccLen)
 		read, err := io.Copy(hsh, rdr)
 		if err != nil {
 			t.Errorf("error reading: %v", err)

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2014 Tamás Gulácsi.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0. Unless required by applicable law
+or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package rs
+
+import (
+	"io"
+)
+
+const maxDataLen = 255
+
+type rSWriter struct {
+	dataLen, eccLen int
+	e               Encoder
+	w               io.Writer
+	block           []byte
+	rest            []byte
+}
+
+// NewWriter returns a new writer with c ECC-length
+func NewWriter(w io.Writer, c int) io.Writer {
+	return &rSWriter{
+		dataLen: maxDataLen - c,
+		eccLen:  c,
+		e:       NewEncoder(QR_CODE_FIELD_256, c),
+		w:       w,
+		block:   make([]byte, maxDataLen),
+		rest:    make([]byte, 0, maxDataLen-c)}
+}
+
+func (wr *rSWriter) Write(p []byte) (int, error) {
+	dataLen := wr.dataLen
+	if len(p)+len(wr.rest) < dataLen {
+		wr.rest = append(wr.rest, p...)
+		return 0, nil
+	}
+
+	n := 0
+	i := len(wr.rest)
+	if i > 0 {
+		copy(wr.block, wr.rest)
+		wr.rest = wr.rest[:0]
+	}
+
+	k := dataLen - (len(p) + i)
+	for k > 0 {
+		copy(wr.block[i:], p[:k])
+		p = p[k:]
+		i, k = 0, dataLen-len(p)
+		wr.e.Encode(wr.block[:dataLen], wr.block[dataLen:])
+		if m, err := wr.w.Write(wr.block); err != nil {
+			return m, err
+		}
+		n += dataLen
+	}
+
+	if len(p) > 0 {
+		wr.rest = append(wr.rest, p...)
+	}
+	return n, nil
+}
+
+func (wr *rSWriter) Flush() (int, error) {
+	n := len(wr.rest)
+	if n == 0 {
+		return 0, nil
+	}
+	copy(wr.block, wr.rest)
+	dataLen := wr.dataLen
+	// shortening means fillup with zeroes, but don't transmit them
+	for i := n; i < dataLen; i++ {
+		wr.block[i] = 0
+	}
+	wr.e.Encode(wr.block[:dataLen], wr.block[dataLen:])
+	wr.rest = wr.rest[:0]
+	// don't transmit means cut
+	copy(wr.block[n:], wr.block[dataLen:])
+	return wr.w.Write(wr.block[:n+wr.eccLen])
+}
+
+func (wr *rSWriter) Close() error {
+	_, err := wr.Flush()
+	return err
+}

--- a/writer.go
+++ b/writer.go
@@ -28,12 +28,12 @@ type rSWriter struct {
 	rest            []byte
 }
 
-// NewWriter returns a new writer with c ECC-length
-func NewWriter(w io.Writer, c int) io.WriteCloser {
+// NewWriter returns a new writer with f field and c ECC-length
+func NewWriter(w io.Writer, f *Field, c int) io.WriteCloser {
 	return &rSWriter{
 		dataLen: maxDataLen - c,
 		eccLen:  c,
-		e:       NewEncoder(QR_CODE_FIELD_256, c),
+		e:       NewEncoder(f, c),
 		w:       w,
 		block:   make([]byte, maxDataLen),
 		rest:    make([]byte, 0, maxDataLen-c)}


### PR DESCRIPTION
Hi,

I've implemented a Reader and a Writer, hope this can be used!

Now the ecc bytes are written at the end of each block, thus the ecc bytes are interleaved with the original data bytes. I've only a vague idea what shall be a multi-level Reed-Solomon coding to achieve more safety even for erasure of whole 4096 byte blocks...
Can you give me some pointers?
(My vague idea is to write the first level ecc bytes to a buffer and whenever this buffer reaches the 255 byte threshold, then write out a "meta" ecc block for these - this could be a second level ecc. But this would make the reading more complex, imho)

Thanks,
Tamás Gulácsi
