### PR TITLE
Reduce number of copy operations in Decode

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -145,17 +145,42 @@ func BenchmarkDecode16_10(b *testing.B) {
 		}
 	}
 }
+func BenchmarkDecodeSingle16_10(b *testing.B) {
+	b.StopTimer()
+	d := NewDecoder(QRCodeField256)
+	complete := getcomplete()
+	b.SetBytes(int64(len(QRCodeTestData) * b.N))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n, err := d.DecodeSingle(complete, len(QRCodeTestECC)); err != nil || n != 0 {
+			b.Fail()
+		}
+	}
+}
 
 func BenchmarkDecode16_10With1Error(b *testing.B) {
 	b.StopTimer()
 	d := NewDecoder(QRCodeField256)
 	data := makecopy(QRCodeTestData)
-	data[1] = data[1] + 1
 	ecc := makecopy(QRCodeTestECC)
 	b.SetBytes(int64(len(data) * b.N))
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		if n, err := d.Decode(makecopy(data), ecc); err != nil || n != 1 {
+		data[1] = data[1] + 1
+		if n, err := d.Decode(data, ecc); err != nil || n != 1 {
+			b.Fail()
+		}
+	}
+}
+func BenchmarkDecodeSingle16_10With1Error(b *testing.B) {
+	b.StopTimer()
+	d := NewDecoder(QRCodeField256)
+	complete := getcomplete()
+	b.SetBytes(int64(len(QRCodeTestData) * b.N))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		complete[1] = complete[1] + 1
+		if n, err := d.DecodeSingle(complete, len(QRCodeTestECC)); err != nil || n != 1 {
 			b.Fail()
 		}
 	}
@@ -177,6 +202,23 @@ func BenchmarkDecode128_16(b *testing.B) {
 	}
 }
 
+func BenchmarkDecodeSingle128_16(b *testing.B) {
+	b.StopTimer()
+	data := makecopy(Rand128)
+	ecc := make([]byte, 16)
+	e := NewEncoder(QRCodeField256, len(ecc))
+	e.Encode(data, ecc)
+	complete := append(data, ecc...)
+	d := NewDecoder(QRCodeField256)
+	b.SetBytes(int64(len(data) * b.N))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n, err := d.DecodeSingle(complete, len(ecc)); err != nil || n != 0 {
+			b.Fail()
+		}
+	}
+}
+
 func BenchmarkDecode128_16With1Error(b *testing.B) {
 	b.StopTimer()
 	data := makecopy(Rand128)
@@ -184,11 +226,29 @@ func BenchmarkDecode128_16With1Error(b *testing.B) {
 	e := NewEncoder(QRCodeField256, len(ecc))
 	e.Encode(data, ecc)
 	d := NewDecoder(QRCodeField256)
-	data[1] = data[1] + 1
 	b.SetBytes(int64(len(data) * b.N))
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		if n, err := d.Decode(makecopy(data), ecc); err != nil || n != 1 {
+		data[1] = data[1] + 1
+		if n, err := d.Decode(data, ecc); err != nil || n != 1 {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkDecodeSingle128_16With1Error(b *testing.B) {
+	b.StopTimer()
+	data := makecopy(Rand128)
+	ecc := make([]byte, 16)
+	e := NewEncoder(QRCodeField256, len(ecc))
+	e.Encode(data, ecc)
+	d := NewDecoder(QRCodeField256)
+	complete := append(data, ecc...)
+	b.SetBytes(int64(len(data) * b.N))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		complete[1] = complete[1] + 1
+		if n, err := d.DecodeSingle(complete, len(ecc)); err != nil || n != 1 {
 			b.Fail()
 		}
 	}
@@ -201,12 +261,31 @@ func BenchmarkDecode128_16With2Error(b *testing.B) {
 	e := NewEncoder(QRCodeField256, len(ecc))
 	e.Encode(data, ecc)
 	d := NewDecoder(QRCodeField256)
-	data[1] = data[1] + 1
-	ecc[1] = ecc[1] + 1
 	b.SetBytes(int64(len(data) * b.N))
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		if n, err := d.Decode(makecopy(data), makecopy(ecc)); err != nil || n != 2 {
+		data[1] = data[1] + 1
+		ecc[1] = ecc[1] + 1
+		if n, err := d.Decode(data, ecc); err != nil || n != 2 {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkDecodeSingle128_16With2Error(b *testing.B) {
+	b.StopTimer()
+	data := makecopy(Rand128)
+	ecc := make([]byte, 16)
+	e := NewEncoder(QRCodeField256, len(ecc))
+	e.Encode(data, ecc)
+	d := NewDecoder(QRCodeField256)
+	complete := append(data, ecc...)
+	b.SetBytes(int64(len(data) * b.N))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		complete[1] = complete[1] + 1
+		complete[len(data)+1] = complete[len(data)+1] + 1
+		if n, err := d.DecodeSingle(complete, len(ecc)); err != nil || n != 2 {
 			b.Fail()
 		}
 	}


### PR DESCRIPTION
`DecodeSingle` gets a single slice, `data` combined with `ecc`. If possible, using this function instead of `Decode` reduces the memory usage and allocation.

```
goos: linux
goarch: amd64
pkg: github.com/maruel/rs
cpu: 12th Gen Intel(R) Core(TM) i5-12450H
BenchmarkDecode16_10-12                     	 2507281	       479.0 ns/op	83751332.47 MB/s	      48 B/op	       2 allocs/op
BenchmarkDecodeSingle16_10-12               	 2553074	       457.3 ns/op	89333181.87 MB/s	      16 B/op	       1 allocs/op
BenchmarkDecode16_10With1Error-12           	 1266762	      1037 ns/op	19535895.82 MB/s	     512 B/op	      27 allocs/op
BenchmarkDecodeSingle16_10With1Error-12     	 1000000	      1006 ns/op	15899815.31 MB/s	     480 B/op	      26 allocs/op
BenchmarkDecode128_16-12                    	  200122	      6170 ns/op	4151483.66 MB/s	     160 B/op	       2 allocs/op
BenchmarkDecodeSingle128_16-12              	  202068	      6001 ns/op	4309959.18 MB/s	      16 B/op	       1 allocs/op
BenchmarkDecode128_16With1Error-12          	  178846	      6609 ns/op	3463615.24 MB/s	     662 B/op	      27 allocs/op
BenchmarkDecodeSingle128_16With1Error-12    	  180782	      6521 ns/op	3548558.03 MB/s	     518 B/op	      26 allocs/op
BenchmarkDecode128_16With2Error-12          	  163591	      7252 ns/op	2887260.40 MB/s	    1032 B/op	      45 allocs/op
BenchmarkDecodeSingle128_16With2Error-12    	  164965	      7267 ns/op	2905602.99 MB/s	     888 B/op	      44 allocs/op
PASS
ok  	github.com/maruel/rs	14.251s
```